### PR TITLE
swap ngmin out in favor of ng-annotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ as a starting point.
 
 This plugin will configure your lineman project to incorporate:
 
- * **grunt-ngmin** to handle minification, replacing uglify, in order to deal with Angular's function#toString()'ing to figure out what to inject into your methods.
- * **grunt-angular-templates** to compile the client-side `*.html` templates you add to `app/templates`
+* [**grunt-ng-annotate**][ng-annotate] to prevent minification from destroying Angular's ability to see what dependencies should be injected.
+* [**grunt-angular-templates**][angular-templates] to compile the client-side `*.html` templates you add to `app/templates`
+
+[ng-annotate]: https://github.com/olov/ng-annotate
+[angular-templates]: https://github.com/ericclemmons/grunt-angular-templates
 
 ## Notes
 

--- a/config/plugins/ngmin.coffee
+++ b/config/plugins/ngmin.coffee
@@ -1,12 +1,12 @@
 module.exports = (lineman) ->
 
   config:
-    loadNpmTasks: lineman.config.application.loadNpmTasks.concat("grunt-ngmin")
+    loadNpmTasks: lineman.config.application.loadNpmTasks.concat("grunt-ng-annotate")
 
     prependTasks:
-      dist: lineman.config.application.prependTasks.dist.concat("ngmin")
+      dist: lineman.config.application.prependTasks.dist.concat("ngAnnotate")
 
-    ngmin:
+    ngAnnotate:
       js:
         src: "<%= files.js.concatenated %>"
         dest: "<%= files.js.concatenated %>"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "grunt-angular-templates": "~0.3.8",
-    "grunt-ngmin": "~0.0.3",
+    "grunt-ng-annotate": "~0.3.0",
     "coffee-script": "~1.6.3",
     "underscore": "~1.5.2"
   },


### PR DESCRIPTION
ngmin is deprecated in favor of ng-annotate

I checked the minified output and it looks the same. Build time is much faster.

The only thing I am concerned about is that anyone upgrading lineman-angular who has special ngmin config will have to change the key in their config file, right?
