### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "grunt-angular-templates": "^0.3.8",
-    "grunt-ng-annotate": "^0.3.2",
+    "grunt-ng-annotate": "^1.0.1",
     "coffee-script": "^1.6.3",
     "underscore": "^1.5.2"
   },


### PR DESCRIPTION
Hi,

The old version of grunt-ng-annotate (0.3.2) was doing bad things when munging angular-google-maps and making my app really sad.  I updated locally to 1.0.1 and it works correctly now.

Specifically it was turning this:

```
var controller = function ($scope, $element) {           

  var _m = $scope.map;                                   

  self.addInfoWindow = function (lat, lng, content) {    
    _m.addInfoWindow(lat, lng, content);                 
  };                                                     
};                                                       

controller.$inject = ['$scope', '$element'];
```

into this:

```
var controller = ["$scope", "$element", function ($scope, $element) {

  var _m = $scope.map;

  self.addInfoWindow = function (lat, lng, content) {
    _m.addInfoWindow(lat, lng, content);
  };
}];

controller.$inject = ['$scope', '$element'];
```

which caused injection errors.

Thank you for maintaining this.
